### PR TITLE
클래스의 분리

### DIFF
--- a/src/main/java/tobyspring/hellospring/payment/Client.java
+++ b/src/main/java/tobyspring/hellospring/payment/Client.java
@@ -1,7 +1,5 @@
 package tobyspring.hellospring.payment;
 
-import tobyspring.hellospring.payment.service.SimpleExRatePaymentService;
-import tobyspring.hellospring.payment.service.WebApiExRatePaymentService;
 import tobyspring.hellospring.payment.dao.Payment;
 import tobyspring.hellospring.payment.service.PaymentService;
 
@@ -10,7 +8,7 @@ import java.math.BigDecimal;
 
 public class Client {
     public static void main(String[] args) throws IOException {
-        PaymentService paymentService = new SimpleExRatePaymentService();
+        PaymentService paymentService = new PaymentService();
         Payment payment = paymentService.prepare(1L, "USD", BigDecimal.valueOf(1304));
         System.out.println("payment = " + payment);
     }

--- a/src/main/java/tobyspring/hellospring/payment/dao/ExRateDate.java
+++ b/src/main/java/tobyspring/hellospring/payment/dao/ExRateDate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import java.math.BigDecimal;
 import java.util.Map;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ExRateDate(String result, Map<String, BigDecimal> rates) {
 

--- a/src/main/java/tobyspring/hellospring/payment/service/PaymentService.java
+++ b/src/main/java/tobyspring/hellospring/payment/service/PaymentService.java
@@ -6,14 +6,18 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
-abstract public class PaymentService {
+public class PaymentService {
+    private final WebApiExRateProvdier exRateProvdier;
+
+    public PaymentService() {
+        this.exRateProvdier = new WebApiExRateProvdier();
+    }
+
     public Payment prepare(Long orderId, String currency, BigDecimal foreignCurrencyAmount) throws IOException {
-        BigDecimal exRate = getExRate(currency);
+        BigDecimal exRate = exRateProvdier.getExRate(currency);
         BigDecimal convertedAmount = foreignCurrencyAmount.multiply(exRate);
         LocalDateTime validUntil = LocalDateTime.now().plusMinutes(30);
 
         return new Payment(orderId, currency, foreignCurrencyAmount, exRate, convertedAmount, validUntil);
     }
-
-    protected abstract BigDecimal getExRate(String currency) throws IOException;
 }

--- a/src/main/java/tobyspring/hellospring/payment/service/SimpleExRateProvider.java
+++ b/src/main/java/tobyspring/hellospring/payment/service/SimpleExRateProvider.java
@@ -1,12 +1,10 @@
 package tobyspring.hellospring.payment.service;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 
-public class SimpleExRatePaymentService extends PaymentService{
-    @Override
+public class SimpleExRateProvider {
     protected BigDecimal getExRate(String currency) {
-        if(currency.equals("USD")) return BigDecimal.valueOf(1000);
+        if (currency.equals("USD")) return BigDecimal.valueOf(1000);
         throw new IllegalArgumentException("지원되지 않는 통화입니다.");
     }
 }

--- a/src/main/java/tobyspring/hellospring/payment/service/WebApiExRateProvdier.java
+++ b/src/main/java/tobyspring/hellospring/payment/service/WebApiExRateProvdier.java
@@ -2,7 +2,6 @@ package tobyspring.hellospring.payment.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import tobyspring.hellospring.payment.dao.ExRateDate;
-import tobyspring.hellospring.payment.service.PaymentService;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -12,8 +11,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.stream.Collectors;
 
-public class WebApiExRatePaymentService extends PaymentService {
-    @Override
+public class WebApiExRateProvdier {
     protected BigDecimal getExRate(String currency) throws IOException {
         URL url = new URL("https://open.er-api.com/v6/latest/" + currency);
         HttpURLConnection urlConnection = (HttpURLConnection) url.openConnection();


### PR DESCRIPTION
**클래스의 분리**

상속을 받는데는 한계가있다.

자바는 단일 상속원칙
또, 상속은 상위와 하위의 결합이 너무 견고하게 되어있어서

복잡하다.

그래서 클래스를 분리하여 하나의 서비스를 두고 상속을 제거한채로 provider를 만들어준다.
하지만 이 방법도 일일이 하나씩 변경해 줘야한다는 단점이있다.